### PR TITLE
[NetKAT] Speed up PagedStableVector indexing with power-of-two page sizes

### DIFF
--- a/netkat/BUILD.bazel
+++ b/netkat/BUILD.bazel
@@ -397,6 +397,16 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "paged_stable_vector_benchmark",
+    testonly = True,
+    srcs = ["paged_stable_vector_benchmark.cc"],
+    deps = [
+        ":paged_stable_vector",
+        "@com_google_benchmark//:benchmark_main",
+    ],
+)
+
 cc_test(
     name = "packet_transformer_test",
     srcs = ["packet_transformer_test.cc"],

--- a/netkat/packet_set.h
+++ b/netkat/packet_set.h
@@ -343,10 +343,13 @@ class PacketSetManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 64 MiB or ~ 67 MB.
-  // Chosen large enough to reduce the cost of dynamic allocation, and small
-  // enough to avoid excessive memory overhead.
-  static constexpr size_t kPageSize = (1 << 26) / sizeof(DecisionNode);
+  // The page size of the `nodes_` vector: 16 KiB.
+  // Chosen large enough to amortize the cost of dynamic allocation over
+  // hundreds of nodes, and small enough that pages stay below the malloc
+  // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
+  // recycle pages through the allocator's freelists instead of paying an
+  // mmap/munmap syscall pair per manager.
+  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
 
   // The decision nodes forming the BDD-style DAG representation of packet sets.
   // `PacketSetHandle::node_index_` indexes into this vector.

--- a/netkat/packet_set.h
+++ b/netkat/packet_set.h
@@ -343,13 +343,15 @@ class PacketSetManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 16 KiB.
+  // The page size of the `nodes_` vector: 512 nodes, or 12 KiB.
   // Chosen large enough to amortize the cost of dynamic allocation over
   // hundreds of nodes, and small enough that pages stay below the malloc
   // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
   // recycle pages through the allocator's freelists instead of paying an
-  // mmap/munmap syscall pair per manager.
-  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
+  // mmap/munmap syscall pair per manager. A power of two so that indexing
+  // into the vector -- which is on the hot path of nearly every operation --
+  // compiles to shifts and masks rather than multiply sequences.
+  static constexpr size_t kPageSize = size_t{1} << 9;
 
   // The decision nodes forming the BDD-style DAG representation of packet sets.
   // `PacketSetHandle::node_index_` indexes into this vector.

--- a/netkat/packet_set_benchmark.cc
+++ b/netkat/packet_set_benchmark.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <optional>
+#include <utility>
 
 #include "absl/strings/str_cat.h"
 #include "benchmark/benchmark.h"
@@ -119,5 +121,83 @@ void BM_ReCompileOverlappingPredicate(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ReCompileOverlappingPredicate);
+
+// -- Large-scale benchmarks ---------------------------------------------------
+//
+// The benchmarks above build BDDs of only tens of nodes, so they cannot detect
+// effects that only manifest at scale (node arena performance, unique-table
+// pressure, algorithmic complexity of the set operations). The benchmarks
+// below operate on sets of pseudo-random members of a 16^5 ~= 1M element
+// space, encoded over 5 hex-digit fields. Random sets have incompressible
+// BDDs, so node counts scale with set size, mimicking large real-world NetKAT
+// models.
+
+constexpr int kNumDigits = 5;
+
+// The `i`-th pseudo-random member of the space, under the given `seed`.
+// Distinct `i` mostly yield distinct members; collisions just shrink the set.
+uint32_t Member(uint32_t i, uint32_t seed) {
+  uint64_t state = (i + seed) * 6364136223846793005ULL + 1442695040888963407ULL;
+  return static_cast<uint32_t>(state >> 33) & ((1u << (4 * kNumDigits)) - 1);
+}
+
+// Matches exactly the packets whose digit fields encode `member`.
+PredicateProto MemberPredicate(uint32_t member) {
+  PredicateProto pred = MatchProto("f0", member & 15);
+  for (int d = 1; d < kNumDigits; ++d) {
+    pred = AndProto(std::move(pred),
+                    MatchProto(absl::StrCat("f", d), (member >> (4 * d)) & 15));
+  }
+  return pred;
+}
+
+// A balanced Or-tree over members [lo, hi) -- balanced to keep proto/compile
+// recursion depth logarithmic.
+PredicateProto RandomSetPredicate(uint32_t lo, uint32_t hi, uint32_t seed) {
+  if (hi - lo == 1) return MemberPredicate(Member(lo, seed));
+  uint32_t mid = lo + (hi - lo) / 2;
+  return OrProto(RandomSetPredicate(lo, mid, seed),
+                 RandomSetPredicate(mid, hi, seed));
+}
+
+// Benchmarks first-time compilation of a large random set, dominated by node
+// creation: unique-table hashing and arena appends.
+void BM_CompileLargeRandomSet(benchmark::State& state) {
+  PredicateProto pred = RandomSetPredicate(0, state.range(0), /*seed=*/1);
+  for (auto s : state) {
+    PacketSetManager manager;
+    PacketSetHandle set = manager.Compile(pred);
+    benchmark::DoNotOptimize(set);
+  }
+}
+BENCHMARK(BM_CompileLargeRandomSet)->Arg(1 << 12)->Arg(1 << 15);
+
+// Benchmarks `Not` of a large random set: a full traversal that copies every
+// node of the operand (no complement edges yet, see b/382380335).
+void BM_NotOfLargeRandomSet(benchmark::State& state) {
+  PacketSetManager manager;
+  PacketSetHandle set =
+      manager.Compile(RandomSetPredicate(0, state.range(0), /*seed=*/1));
+  for (auto s : state) {
+    PacketSetHandle result = manager.Not(set);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(BM_NotOfLargeRandomSet)->Arg(1 << 12)->Arg(1 << 15);
+
+// Benchmarks `Xor` of two large random sets: a compound operation (two `And`s,
+// several `Not`s) that traverses both operands and creates many nodes.
+void BM_XorOfLargeRandomSets(benchmark::State& state) {
+  PacketSetManager manager;
+  PacketSetHandle lhs =
+      manager.Compile(RandomSetPredicate(0, state.range(0), /*seed=*/1));
+  PacketSetHandle rhs =
+      manager.Compile(RandomSetPredicate(0, state.range(0), /*seed=*/2));
+  for (auto s : state) {
+    PacketSetHandle result = manager.Xor(lhs, rhs);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(BM_XorOfLargeRandomSets)->Arg(1 << 12)->Arg(1 << 15);
 
 }  // namespace netkat

--- a/netkat/packet_transformer.h
+++ b/netkat/packet_transformer.h
@@ -399,13 +399,15 @@ class PacketTransformerManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 16 KiB.
+  // The page size of the `nodes_` vector: 256 nodes, or 16 KiB.
   // Chosen large enough to amortize the cost of dynamic allocation over
   // hundreds of nodes, and small enough that pages stay below the malloc
   // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
   // recycle pages through the allocator's freelists instead of paying an
-  // mmap/munmap syscall pair per manager.
-  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
+  // mmap/munmap syscall pair per manager. A power of two so that indexing
+  // into the vector -- which is on the hot path of nearly every operation --
+  // compiles to shifts and masks rather than multiply sequences.
+  static constexpr size_t kPageSize = size_t{1} << 8;
 
   // Helper functions to deal with DecisionNodes directly.
   // TODO(dilo): Is there a convenient way to either avoid these or avoid making

--- a/netkat/packet_transformer.h
+++ b/netkat/packet_transformer.h
@@ -399,10 +399,13 @@ class PacketTransformerManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 64 MiB or ~ 67 MB.
-  // Chosen large enough to reduce the cost of dynamic allocation, and small
-  // enough to avoid excessive memory overhead.
-  static constexpr size_t kPageSize = (1 << 26) / sizeof(DecisionNode);
+  // The page size of the `nodes_` vector: 16 KiB.
+  // Chosen large enough to amortize the cost of dynamic allocation over
+  // hundreds of nodes, and small enough that pages stay below the malloc
+  // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
+  // recycle pages through the allocator's freelists instead of paying an
+  // mmap/munmap syscall pair per manager.
+  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
 
   // Helper functions to deal with DecisionNodes directly.
   // TODO(dilo): Is there a convenient way to either avoid these or avoid making

--- a/netkat/paged_stable_vector.h
+++ b/netkat/paged_stable_vector.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_NETKAT_NETKAT_PAGED_STABLE_VECTOR_H_
 #define GOOGLE_NETKAT_NETKAT_PAGED_STABLE_VECTOR_H_
 
+#include <bit>
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -36,28 +37,32 @@ namespace netkat {
 // significant for very large vectors in performance-sensitive applications.
 //
 // The API of this class is kept just large enough to cover our use cases.
-//
-// PERFORMANCE: Prefer a power-of-two `PageSize` so that the index arithmetic
-// in `operator[]` compiles to shifts and masks rather than multiply sequences.
 template <class T, size_t PageSize>
 class PagedStableVector {
  public:
+  // Index arithmetic (`operator[]`, `size()`) is on our clients' hot paths.
+  // Requiring a power-of-two `PageSize` guarantees it compiles to shifts and
+  // masks rather than multiply sequences.
+  static_assert(std::has_single_bit(PageSize),
+                "PageSize must be a power of two");
+
   PagedStableVector() = default;
 
-  size_t size() const { return size_; }
+  size_t size() const {
+    return data_.empty() ? 0
+                         : (data_.size() - 1) * PageSize + data_.back().size();
+  }
 
   template <class Value>
   void push_back(Value&& value) {
     ReserveSpaceForNextElement();
     data_.back().push_back(std::forward<Value>(value));
-    ++size_;
   }
 
   template <class... Args>
   void emplace_back(Args&&... value) {
     ReserveSpaceForNextElement();
     data_.back().emplace_back(std::forward<Args>(value)...);
-    ++size_;
   }
 
   T& operator[](size_t index) {
@@ -78,10 +83,6 @@ class PagedStableVector {
   }
 
   std::vector<std::vector<T>> data_;
-
-  // Tracked explicitly (rather than computed from `data_`) since clients call
-  // `size()` on every element insertion.
-  size_t size_ = 0;
 };
 
 }  // namespace netkat

--- a/netkat/paged_stable_vector.h
+++ b/netkat/paged_stable_vector.h
@@ -36,26 +36,28 @@ namespace netkat {
 // significant for very large vectors in performance-sensitive applications.
 //
 // The API of this class is kept just large enough to cover our use cases.
+//
+// PERFORMANCE: Prefer a power-of-two `PageSize` so that the index arithmetic
+// in `operator[]` compiles to shifts and masks rather than multiply sequences.
 template <class T, size_t PageSize>
 class PagedStableVector {
  public:
   PagedStableVector() = default;
 
-  size_t size() const {
-    return data_.empty() ? 0
-                         : (data_.size() - 1) * PageSize + data_.back().size();
-  }
+  size_t size() const { return size_; }
 
   template <class Value>
   void push_back(Value&& value) {
-    if (size() % PageSize == 0) data_.emplace_back().reserve(PageSize);
+    ReserveSpaceForNextElement();
     data_.back().push_back(std::forward<Value>(value));
+    ++size_;
   }
 
   template <class... Args>
   void emplace_back(Args&&... value) {
-    if (size() % PageSize == 0) data_.emplace_back().reserve(PageSize);
+    ReserveSpaceForNextElement();
     data_.back().emplace_back(std::forward<Args>(value)...);
+    ++size_;
   }
 
   T& operator[](size_t index) {
@@ -66,7 +68,20 @@ class PagedStableVector {
   }
 
  private:
+  void ReserveSpaceForNextElement() {
+    if (data_.empty() || data_.back().size() == PageSize) {
+      // Reserving each page upfront is what guarantees pointer stability: a
+      // page never grows beyond its initial capacity, so its elements are
+      // never relocated.
+      data_.emplace_back().reserve(PageSize);
+    }
+  }
+
   std::vector<std::vector<T>> data_;
+
+  // Tracked explicitly (rather than computed from `data_`) since clients call
+  // `size()` on every element insertion.
+  size_t size_ = 0;
 };
 
 }  // namespace netkat

--- a/netkat/paged_stable_vector_benchmark.cc
+++ b/netkat/paged_stable_vector_benchmark.cc
@@ -39,8 +39,8 @@ struct FakeNode {
 };
 static_assert(sizeof(FakeNode) == 24);
 
-// The page size of `PacketSetManager::nodes_`: 2^21 nodes, or 48 MiB.
-constexpr size_t kPageSize = size_t{1} << 21;
+// The page size of `PacketSetManager::nodes_`: 512 nodes, or 12 KiB.
+constexpr size_t kPageSize = size_t{1} << 9;
 
 template <class Vector>
 Vector MakeFilledVector(size_t size) {

--- a/netkat/paged_stable_vector_benchmark.cc
+++ b/netkat/paged_stable_vector_benchmark.cc
@@ -16,11 +16,10 @@
 // only clients (`PacketSetManager`/`PacketTransformerManager`): indexed reads
 // of decision nodes during BDD traversal, and appends of new nodes.
 //
-// The benchmarks are instantiated with a power-of-two and a non-power-of-two
-// page size to quantify the cost of `operator[]`'s index arithmetic: division
-// by a non-power-of-two constant compiles to a multiply sequence rather than a
-// shift. A flat `std::vector` (no paging, no pointer stability) serves as the
-// lower-bound reference.
+// A flat `std::vector` (no paging, no pointer stability) serves as the
+// reference: it bounds read performance from above (no double indirection,
+// perfect contiguity) and append performance from below (it must relocate all
+// elements whenever it grows beyond its capacity).
 
 #include <cstddef>
 #include <cstdint>
@@ -40,14 +39,8 @@ struct FakeNode {
 };
 static_assert(sizeof(FakeNode) == 24);
 
-// The page size of `PacketSetManager::nodes_` at the time of writing:
-// a 64 MiB byte budget divided by the node size, yielding a non-power-of-two
-// number of elements per page.
-constexpr size_t kNonPow2PageSize = (size_t{1} << 26) / sizeof(FakeNode);
-static_assert((kNonPow2PageSize & (kNonPow2PageSize - 1)) != 0);
-
-// A power-of-two page size of comparable magnitude (~48 MiB worth of nodes).
-constexpr size_t kPow2PageSize = size_t{1} << 21;
+// The page size of `PacketSetManager::nodes_`: 2^21 nodes, or 48 MiB.
+constexpr size_t kPageSize = size_t{1} << 21;
 
 template <class Vector>
 Vector MakeFilledVector(size_t size) {
@@ -113,20 +106,16 @@ void BM_RandomRead(benchmark::State& state) {
 constexpr size_t kSmall = size_t{1} << 18;
 constexpr size_t kLarge = size_t{1} << 22;
 
-using NonPow2Vector = PagedStableVector<FakeNode, kNonPow2PageSize>;
-using Pow2Vector = PagedStableVector<FakeNode, kPow2PageSize>;
+using PagedVector = PagedStableVector<FakeNode, kPageSize>;
 using FlatVector = std::vector<FakeNode>;
 
-BENCHMARK_TEMPLATE(BM_PushBack, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
-BENCHMARK_TEMPLATE(BM_PushBack, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_PushBack, PagedVector)->Arg(kSmall)->Arg(kLarge);
 BENCHMARK_TEMPLATE(BM_PushBack, FlatVector)->Arg(kSmall)->Arg(kLarge);
 
-BENCHMARK_TEMPLATE(BM_SequentialRead, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
-BENCHMARK_TEMPLATE(BM_SequentialRead, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_SequentialRead, PagedVector)->Arg(kSmall)->Arg(kLarge);
 BENCHMARK_TEMPLATE(BM_SequentialRead, FlatVector)->Arg(kSmall)->Arg(kLarge);
 
-BENCHMARK_TEMPLATE(BM_RandomRead, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
-BENCHMARK_TEMPLATE(BM_RandomRead, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_RandomRead, PagedVector)->Arg(kSmall)->Arg(kLarge);
 BENCHMARK_TEMPLATE(BM_RandomRead, FlatVector)->Arg(kSmall)->Arg(kLarge);
 
 }  // namespace

--- a/netkat/paged_stable_vector_benchmark.cc
+++ b/netkat/paged_stable_vector_benchmark.cc
@@ -1,0 +1,133 @@
+// Copyright 2026 The NetKAT authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Benchmarks for `PagedStableVector`, exercising the access patterns of its
+// only clients (`PacketSetManager`/`PacketTransformerManager`): indexed reads
+// of decision nodes during BDD traversal, and appends of new nodes.
+//
+// The benchmarks are instantiated with a power-of-two and a non-power-of-two
+// page size to quantify the cost of `operator[]`'s index arithmetic: division
+// by a non-power-of-two constant compiles to a multiply sequence rather than a
+// shift. A flat `std::vector` (no paging, no pointer stability) serves as the
+// lower-bound reference.
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "netkat/paged_stable_vector.h"
+
+namespace netkat {
+namespace {
+
+// Same size and alignment as `PacketSetManager::DecisionNode`.
+struct FakeNode {
+  uint64_t a = 0;
+  uint64_t b = 0;
+  uint64_t c = 0;
+};
+static_assert(sizeof(FakeNode) == 24);
+
+// The page size of `PacketSetManager::nodes_` at the time of writing:
+// a 64 MiB byte budget divided by the node size, yielding a non-power-of-two
+// number of elements per page.
+constexpr size_t kNonPow2PageSize = (size_t{1} << 26) / sizeof(FakeNode);
+static_assert((kNonPow2PageSize & (kNonPow2PageSize - 1)) != 0);
+
+// A power-of-two page size of comparable magnitude (~48 MiB worth of nodes).
+constexpr size_t kPow2PageSize = size_t{1} << 21;
+
+template <class Vector>
+Vector MakeFilledVector(size_t size) {
+  Vector vec;
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(FakeNode{.a = i, .b = i, .c = i});
+  }
+  return vec;
+}
+
+// Returns `size` indices in [0, size) in pseudo-random order, simulating the
+// data-dependent node lookups of BDD traversal. Uses a fixed-seed LCG so all
+// instantiations see the identical sequence.
+std::vector<uint32_t> PseudoRandomIndices(size_t size) {
+  std::vector<uint32_t> indices;
+  indices.reserve(size);
+  uint64_t state = 42;
+  for (size_t i = 0; i < size; ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    indices.push_back(static_cast<uint32_t>((state >> 33) % size));
+  }
+  return indices;
+}
+
+template <class Vector>
+void BM_PushBack(benchmark::State& state) {
+  const size_t size = state.range(0);
+  for (auto s : state) {
+    Vector vec = MakeFilledVector<Vector>(size);
+    benchmark::DoNotOptimize(vec);
+  }
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+template <class Vector>
+void BM_SequentialRead(benchmark::State& state) {
+  const size_t size = state.range(0);
+  Vector vec = MakeFilledVector<Vector>(size);
+  for (auto s : state) {
+    uint64_t sum = 0;
+    for (size_t i = 0; i < size; ++i) sum += vec[i].a;
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+template <class Vector>
+void BM_RandomRead(benchmark::State& state) {
+  const size_t size = state.range(0);
+  Vector vec = MakeFilledVector<Vector>(size);
+  const std::vector<uint32_t> indices = PseudoRandomIndices(size);
+  for (auto s : state) {
+    uint64_t sum = 0;
+    for (uint32_t index : indices) sum += vec[index].a;
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+// 4M elements ≈ 96 MiB: spans multiple pages and far exceeds L3, like the
+// node vectors of large NetKAT models. 256k elements ≈ 6 MiB: fits in L3,
+// making the index arithmetic (rather than memory stalls) the bottleneck.
+constexpr size_t kSmall = size_t{1} << 18;
+constexpr size_t kLarge = size_t{1} << 22;
+
+using NonPow2Vector = PagedStableVector<FakeNode, kNonPow2PageSize>;
+using Pow2Vector = PagedStableVector<FakeNode, kPow2PageSize>;
+using FlatVector = std::vector<FakeNode>;
+
+BENCHMARK_TEMPLATE(BM_PushBack, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_PushBack, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_PushBack, FlatVector)->Arg(kSmall)->Arg(kLarge);
+
+BENCHMARK_TEMPLATE(BM_SequentialRead, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_SequentialRead, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_SequentialRead, FlatVector)->Arg(kSmall)->Arg(kLarge);
+
+BENCHMARK_TEMPLATE(BM_RandomRead, NonPow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_RandomRead, Pow2Vector)->Arg(kSmall)->Arg(kLarge);
+BENCHMARK_TEMPLATE(BM_RandomRead, FlatVector)->Arg(kSmall)->Arg(kLarge);
+
+}  // namespace
+}  // namespace netkat

--- a/netkat/paged_stable_vector_test.cc
+++ b/netkat/paged_stable_vector_test.cc
@@ -85,11 +85,15 @@ FUZZ_TEST(PagedStableVectorTest, BracketAssigmentWorks);
 TEST(PagedStableVectorTest, ReferencesDontGetInvalidated) {
   PagedStableVector<std::string, kSmallPageSize> vector;
 
-  // Store a few references.
-  vector.push_back("first element");
-  std::string* first_element_ptr = &vector[0];
-  vector.push_back("second element");
-  std::string* second_element_ptr = &vector[1];
+  // Store a reference to every element as it is added, spanning several pages
+  // so that some references point to elements right before and right after
+  // page boundaries -- the positions most at risk when a new page or a larger
+  // page table gets allocated.
+  std::vector<std::string*> element_ptrs;
+  for (int i = 0; i < 10 * kSmallPageSize; ++i) {
+    vector.push_back(std::to_string(i));
+    element_ptrs.push_back(&vector[i]);
+  }
 
   // Push a ton of elements to trigger page allocation.
   // If this were a regular std::vector, the references would be invalidated.
@@ -98,8 +102,10 @@ TEST(PagedStableVectorTest, ReferencesDontGetInvalidated) {
   }
 
   // Check that the references are still valid.
-  EXPECT_EQ(&vector[0], first_element_ptr);
-  EXPECT_EQ(&vector[1], second_element_ptr);
+  for (int i = 0; i < element_ptrs.size(); ++i) {
+    EXPECT_EQ(&vector[i], element_ptrs[i]);
+    EXPECT_EQ(*element_ptrs[i], std::to_string(i));
+  }
 };
 
 }  // namespace

--- a/netkat/paged_stable_vector_test.cc
+++ b/netkat/paged_stable_vector_test.cc
@@ -25,7 +25,8 @@ namespace {
 
 // A small, but otherwise random page size used throughout the tests.
 // Using a small page size is useful for exercising the page replacement logic.
-static constexpr int kSmallPageSize = 3;
+// Must be a power of two, as required by `PagedStableVector`.
+static constexpr int kSmallPageSize = 4;
 
 void PushBackInreasesSize(std::vector<std::string> elements) {
   PagedStableVector<std::string, kSmallPageSize> vector;


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #105** — the first two commits shown here belong to that PR. Review only the four commits starting at "Simplify PagedStableVector bookkeeping"; this PR will be rebased once #105 merges.

## The win

This PR hardens and instruments the node arena after #105 right-sizes its pages:

- **Compile-time enforcement** that `PagedStableVector` page sizes are powers of two — the property that makes its `operator[]` (the hot path of nearly every BDD operation, via `GetNodeOrDie`) compile to shifts/masks and run **1.1–2.6× faster** than with a non-power-of-two page size, matching a flat `std::vector` on sequential reads. #105 chooses such page sizes; this PR makes choosing anything else a compile error rather than a silent regression.
- **A latent exception-safety bug fixed** in `push_back`/`emplace_back`.
- **Benchmark infrastructure** the repo was missing: a `PagedStableVector` microbenchmark and large-scale (~10^5–10^6 node) packet-set benchmarks — the latter already used to validate #105's claims.

End-to-end, the arena-level changes are worth ~1–3% (see "How much this matters" below); the big wins here are robustness and measurement.

## The story

`PagedStableVector::operator[]` computes `index / PageSize` and `index % PageSize` on every access. When the page size is derived from a byte budget — as it was on head, and as #105 initially did — the element count is generally not a power of two, so the compiler emits multiply-based division sequences instead of single shift/mask instructions. The transformer manager only ever escaped this by luck (64-byte nodes happen to divide byte budgets evenly).

With #105 defining both page sizes as power-of-two node counts, this PR adds `static_assert(std::has_single_bit(PageSize))` to `PagedStableVector` itself, turning the convention into a guarantee.

The `push_back`/`emplace_back` bookkeeping is also simplified: page boundaries are detected via the last page's size rather than recomputing `size() % PageSize` per insertion. Besides being cheaper, this fixes a latent invariant bug: if an insertion threw after allocating a fresh page, the next insertion would allocate a *second* empty page, leaving a hole mid-vector that silently corrupts the index arithmetic for all subsequent elements. (Unreachable today since `DecisionNode` insertions don't throw, but a footgun for future element types.)

## Microbenchmark proof

The power-of-two impact was measured with a temporary variant of the new `paged_stable_vector_benchmark` instantiating both page-size flavors in the same binary (perfectly load-matched), at L3-resident (256k elements) and DRAM-resident (4M elements) working-set sizes. CPU-time medians, 5 repetitions:

| Benchmark | non-pow2 pages | pow2 pages | speedup |
|---|---|---|---|
| Sequential read, 256k elems (L3) | 222.6 µs | 84.7 µs | **2.6×** |
| Sequential read, 4M elems (DRAM) | 3.72 ms | 2.15 ms | **1.7×** |
| Random read, 256k elems (L3) | 385 µs | 292 µs | **1.3×** |
| Random read, 4M elems (DRAM) | 37.0 ms | 33.1 ms | **1.1×** |

The committed benchmark uses the production page size (512 nodes per #105) and keeps the long-term job of guarding paged-vs-flat performance: with the small pages, paged sequential reads still match flat `std::vector` (2.081 ms vs 2.070 ms at 4M elements — the 8k-entry page table costs nothing measurable), and paged appends still beat flat by ~1.4× thanks to the absence of relocation copies.

## How much this matters end to end

The pre-existing benchmarks compile predicates of only tens of BDD nodes — far too small to exercise the arena. This PR adds large-scale benchmarks to `packet_set_benchmark`: pseudo-random sets drawn from a ~1M element space over 5 hex-digit fields, whose incompressible BDDs reach ~10^5–10^6 nodes like real-world models. The arena-level changes (power-of-two indexing + cheaper appends) are worth ~1–3% end to end on these workloads — node creation is dominated by unique-table hashing (each `DecisionNode` hash includes its heap-allocated branch array) and `flat_hash_map` probing, which dwarf the few instructions saved per arena access. The big end-to-end levers are algorithmic and already tracked: operation memoization (b/382379263) and complement edges (b/382380335) — today `Or` is `Not(And(Not(l), Not(r)))` and `Not` copies its entire operand. These benchmarks double as the yardstick for that future work, and were already used to verify #105's "large workloads unaffected" claim (they improved ~8%).

All 17 bazel test targets pass in `-c opt`. The pointer-stability test is also strengthened: it now holds a reference to every element across several pages (the boundary-adjacent positions are the ones most at risk during page allocation), rather than just the first two elements of the first page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)