### PR TITLE
[NetKAT] Shrink node storage pages from 64 MiB to 16 KiB

### DIFF
--- a/netkat/packet_set.h
+++ b/netkat/packet_set.h
@@ -343,10 +343,13 @@ class PacketSetManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 64 MiB or ~ 67 MB.
-  // Chosen large enough to reduce the cost of dynamic allocation, and small
-  // enough to avoid excessive memory overhead.
-  static constexpr size_t kPageSize = (1 << 26) / sizeof(DecisionNode);
+  // The page size of the `nodes_` vector: 16 KiB.
+  // Chosen large enough to amortize the cost of dynamic allocation over
+  // hundreds of nodes, and small enough that pages stay below the malloc
+  // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
+  // recycle pages through the allocator's freelists instead of paying an
+  // mmap/munmap syscall pair per manager.
+  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
 
   // The decision nodes forming the BDD-style DAG representation of packet sets.
   // `PacketSetHandle::node_index_` indexes into this vector.

--- a/netkat/packet_set.h
+++ b/netkat/packet_set.h
@@ -343,13 +343,15 @@ class PacketSetManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 16 KiB.
+  // The page size of the `nodes_` vector: 512 nodes, or 12 KiB.
   // Chosen large enough to amortize the cost of dynamic allocation over
   // hundreds of nodes, and small enough that pages stay below the malloc
   // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
   // recycle pages through the allocator's freelists instead of paying an
-  // mmap/munmap syscall pair per manager.
-  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
+  // mmap/munmap syscall pair per manager. A power of two so that indexing
+  // into the vector -- which is on the hot path of nearly every operation --
+  // compiles to shifts and masks rather than multiply sequences.
+  static constexpr size_t kPageSize = size_t{1} << 9;
 
   // The decision nodes forming the BDD-style DAG representation of packet sets.
   // `PacketSetHandle::node_index_` indexes into this vector.

--- a/netkat/packet_transformer.h
+++ b/netkat/packet_transformer.h
@@ -399,13 +399,15 @@ class PacketTransformerManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 16 KiB.
+  // The page size of the `nodes_` vector: 256 nodes, or 16 KiB.
   // Chosen large enough to amortize the cost of dynamic allocation over
   // hundreds of nodes, and small enough that pages stay below the malloc
   // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
   // recycle pages through the allocator's freelists instead of paying an
-  // mmap/munmap syscall pair per manager.
-  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
+  // mmap/munmap syscall pair per manager. A power of two so that indexing
+  // into the vector -- which is on the hot path of nearly every operation --
+  // compiles to shifts and masks rather than multiply sequences.
+  static constexpr size_t kPageSize = size_t{1} << 8;
 
   // Helper functions to deal with DecisionNodes directly.
   // TODO(dilo): Is there a convenient way to either avoid these or avoid making

--- a/netkat/packet_transformer.h
+++ b/netkat/packet_transformer.h
@@ -399,10 +399,13 @@ class PacketTransformerManager {
 
   [[nodiscard]] std::string ToString(const DecisionNode& node) const;
 
-  // The page size of the `nodes_` vector: 64 MiB or ~ 67 MB.
-  // Chosen large enough to reduce the cost of dynamic allocation, and small
-  // enough to avoid excessive memory overhead.
-  static constexpr size_t kPageSize = (1 << 26) / sizeof(DecisionNode);
+  // The page size of the `nodes_` vector: 16 KiB.
+  // Chosen large enough to amortize the cost of dynamic allocation over
+  // hundreds of nodes, and small enough that pages stay below the malloc
+  // mmap/trim thresholds (typically 128 KiB): this way, short-lived managers
+  // recycle pages through the allocator's freelists instead of paying an
+  // mmap/munmap syscall pair per manager.
+  static constexpr size_t kPageSize = (1 << 14) / sizeof(DecisionNode);
 
   // Helper functions to deal with DecisionNodes directly.
   // TODO(dilo): Is there a convenient way to either avoid these or avoid making


### PR DESCRIPTION
## What

The page size of the managers' node vectors goes from 64 MiB to 12 KiB (packet sets, 512 nodes) / 16 KiB (transformers, 256 nodes), defined directly as power-of-two node counts.

## Why

At 64 MiB, every page allocation exceeds malloc's mmap threshold (typically 128 KiB), so **every manager pays an mmap/munmap syscall pair** — diagnosed with `strace -c`, which shows one mmap+munmap per benchmark iteration on head. This is significant for short-lived managers (compile a policy, answer a query, discard), the dominant pattern in tests and the analysis engine today. At 12–16 KiB, pages stay below the mmap/trim thresholds and are recycled through the allocator's freelists, while still amortizing allocation over hundreds of nodes.

The page sizes are expressed as power-of-two *node counts* rather than derived from a byte budget: a byte-budget division yields a non-power-of-two count for packet sets (16 KiB / 24 B = 682), which would force the index arithmetic in `PagedStableVector::operator[]` — the hot path of nearly every operation — to compile to multiply sequences instead of single shift/mask instructions. (#101, designed to stack on this PR, enforces the power-of-two property at compile time and adds benchmark infrastructure.)

## Measured results (CPU-time medians, 5 reps)

Small-policy compilation, the workload this PR targets, vs head:

| Benchmark | before | after | speedup |
|---|---|---|---|
| `BM_FirstTimeCompileOverlappingPredicate` | 11.2 µs | 3.8 µs | **3.0×** |
| `BM_FirstTimeCompileNonOverlappingPredicate` | 45.0 µs | 36.1 µs | **1.25×** |
| `BM_FirstTimeCompileNonOverlappingPolicy` (transformer) | 585 µs | 266 µs | **2.2×** |
| Recompile benchmarks (no allocation) | ~640 ns | ~635 ns | unchanged |

Large workloads are not just unaffected but slightly improved, verified with the large-scale benchmarks from #101 (random packet sets of ~10^5–10^6 BDD nodes): compiling a 32k-member set goes from 264.6 ms to 243.1 ms (−8%), `Xor` of two 32k-member sets from 3.19 ms to 3.13 ms, `Not` unchanged.

## Testing

All 17 bazel test targets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)